### PR TITLE
Multi-indexed DataFrames, load data from, and write to file on the fly, nametuples and many other improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 # Publish README on PYPI when uploading.
 # Need to expand it and rewrite it in reStructuredText 
-long_descr = open('README.MD', 'r').read()
+long_descr = open('README.md', 'r').read()
 
 setup(name='pysdmx',
 	version='0.1',


### PR DESCRIPTION
There are lots of improvements, most of them commented in thn sdmx.py. Highlights:

data method:

It has some new options: to_file and from_file do what you'd expect. You can work offline and save time for large files that take long to transmit.

If a list of series is returned, each list contains its full metadata as namedtuple. It can be accessed through its 'name' attribute. I did not know of that until yesterday. My comment on one of the issues in your repo is thus wrong. Series can have metadata and I believe namedtuple is the right format.

data() now accepts a boolean arg 'concat'. If it is True, the series from the list are concatenated to a DataFrame. The new method make_dataframe takes advantage of pandas.MultiIndex, one of the coolest features: The metadata is used to created a multi-level index. the doc string of data() contains an example on how to use it. There is one feature missing, yet: reordering the levels. I will implement it shortly. The MultiIndexed dataframes are a breakthrough for pysdmx. So DataFrames do not contain the namedtuples from the Series.

Under the hood:

The date_parser function is no longer used. pandas.to_dates seems to do much better and faster. But this needs further testing. 

I have also refactored some other code to make it more readable and faster. 
The codes method and DataFlows methods, too, accept to_file and from_file parguments. But I haven't tested this.

I have only worked with sdmx v2.1 data, not 2.0. So this needs to be tested as well. 
