### PR TITLE
Fix AttributeError in Request.write_source()

### DIFF
--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -53,7 +53,8 @@ class Reader(BaseReader):
         '''
         Save XML source to file by calling `write` on the root element.
         '''
-        return self.message._elem.write(filename, encoding='utf8')
+        return self.message._elem.getroottree().write(filename,
+                                                      encoding='utf8')
 
     _paths = {
         'footer_text': 'com:Text/text()',


### PR DESCRIPTION
This PR solves (for me at least) the following bug:
```

In [1]:  from pandasdmx import Request

In [2]: resp = Request('ESTAT').data('une_rt_a', key={'GEO': 'EL+ES+IE'}, params={'startPeriod': '2006'})

In [3]: resp.write_source('/tmp/test.xml')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-d7c3947e9658> in <module>()
----> 1 resp.write_source('/tmp/test.xml')

/home/nobackup/repo/pandaSDMX/pandasdmx/api.py in write_source(self, filename)
    488             whatever the LXML deserializer returns.
    489         '''
--> 490         return self.msg._reader.write_source(filename)

/home/nobackup/repo/pandaSDMX/pandasdmx/reader/sdmxml.py in write_source(self, filename)
     54         Save XML source to file by calling `write` on the root element.
     55         '''
---> 56         return self.message._elem.write(filename, encoding='utf8')
     57 
     58     _paths = {

AttributeError: 'lxml.etree._Element' object has no attribute 'write'

```