### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ pandaSDMX
 Description: A Python- and pandas-powered client for statistical data and metadata exchange
 Author: Dr. Leo <fhaxbox66@gmail.com>
 License: Apache 2.0
-Documentation: http://pandasdmx.readthedocs.org
+Documentation: https://pandasdmx.readthedocs.io
 Development website: https://github.com/dr-leo/pandasdmx/
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,7 @@ v0.2.0
 
 * New architecture, rewrite of the entire package
 * Many new functions, new API
-* Sphinx documentation at http://pandasdmx.readthedocs.org
+* Sphinx documentation at https://pandasdmx.readthedocs.io
 
 
 v0.1.2 (2014-09-17)

--- a/description.rst
+++ b/description.rst
@@ -43,13 +43,13 @@ Main features
 
 For further details including extensive code examples
 see the 
-`documentation <http://pandasdmx.readthedocs.io>`_ . 
+`documentation <https://pandasdmx.readthedocs.io>`_ . 
 
 
 pandaSDMX Links
 -------------------------------
 
-* `Documentation <http://pandasdmx.readthedocs.io>`_
+* `Documentation <https://pandasdmx.readthedocs.io>`_
 * `Mailing list <https://groups.google.com/forum/?hl=en#!forum/sdmx-python>`_  
 * `github <https://github.com/dr-leo/pandaSDMX>`_
  

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -2,7 +2,7 @@ pandaSDMX documentation
 =========================================
 
 
-Online documentation is available at http://pandasdmx.readthedocs.io
+Online documentation is available at https://pandasdmx.readthedocs.io
 
 The Sphinx sources are in the github repository, but are not part of the source distribution.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ the gold-standard
 of data analysis in Python. 
 From pandas you can export data and metadata to Excel, R and friends. As from version 0.4, 
 pandaSDMX can export data to many other file formats and
-database backends via `Odo <http://odo.readthedocs.io/>`_. 
+database backends via `Odo <https://odo.readthedocs.io/>`_. 
 
 Main features
 ---------------------

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -494,7 +494,7 @@ be overwritten.
 Using odo to export data sets to other data formats and database backends
 ---------------------------------------------------------------------------
 
-Since version 0.4, pandaSDMX supports `odo <http://odo.readthedocs.io>`_, a great tool to convert data sets
+Since version 0.4, pandaSDMX supports `odo <https://odo.readthedocs.io>`_, a great tool to convert data sets
 to a variety of data formats and database backends. To use this feature, you have to
 call :func:`pandasdmx.odo_register` to register .sdmx files with odo. Then you can
 convert an .sdmx file containing a data set to, say, a CSV file or an SQLite or PostgreSQL database in

--- a/pandasdmx/__init__.py
+++ b/pandasdmx/__init__.py
@@ -37,7 +37,7 @@ logger = _init_logger()
 
 def odo_register():
     '''
-    Enable conversion of .sdmx files with odo (http://odo.readthedocs.org).
+    Enable conversion of .sdmx files with odo (https://odo.readthedocs.io).
     Adds conversion from sdmx to PD.DataFrame to odo graph.
     Note that native discovery of sdmx files is not yet supported. odo will thus 
     convert to PD.DataFrame


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
