### PR TITLE
WIP: horrible patch to have get work on ISTAT's wsdmx data and dataflow endpoints

### DIFF
--- a/pandasdmx/api.py
+++ b/pandasdmx/api.py
@@ -354,6 +354,12 @@ class Request(object):
                 raise ValueError(
                     'If `` url`` is not specified, either agency or fromfile must be given.')
 
+        # horrible patch to have this work on ISTAT's wsdmx
+        # which requires /IT1 (or agency ID) for dataflow requests, 
+        # while does not require it in data requests
+        if self.agency[:5] == 'ISTAT' and resource_type == 'data':
+            base_url = base_url.replace("/IT1", "")
+
         # Now get the SDMX message either via http or as local file
         logger.info(
             'Requesting resource from URL/file %s', (base_url or fromfile))


### PR DESCRIPTION
This is a truly horrible patch to have pandasdmsx's get method work on ISTAT's wsdmx
that requires the IT1 agency code for the dataflow endpoint, while not for the data endpoint

The following two URLs return correct results (200):
http://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/47_850/
http://sdmx.istat.it/SDMXWS/rest/data/47_850/A.001001+001002.1.AUTP.ALL.ALL/

while these return a 404:
http://sdmx.istat.it/SDMXWS/rest/dataflow/47_850/
http://sdmx.istat.it/SDMXWS/rest/data/IT1/47_850/A.001001+001002.1.AUTP.ALL.ALL/

The get method in the API seems to only be able to process URLs having the same format.
When processing data, the dataflow endpoint is requested too,
because of this:
```python
            if resource_type == 'data' and isinstance(key, dict):
                # normalize key making str-type, '+'-separated values a list
                key = self.prepare_key(key)
                # select validation method based on agency capabilities
                if (series_keys and
                        self._agencies[self.agency].get('supports_series_keys_only')):
                    val_resp = self.data(resource_id,
                                         params={'detail': 'serieskeysonly'})
                else:
                    val_resp = self.dataflow(resource_id,
                                             memcache='dataflow' + resource_id)
                    # check if the message contains the datastructure. This is
                    # not the case, eg, for ESTAT. If not, download it.
                    if not hasattr(val_resp.msg, 'datastructure'):
                        val_resp = val_resp.dataflow[resource_id].structure(
                            request=True, target_only=False)
                val_msg = val_resp.msg
                # validate key
                val_msg.in_constraints(key)
                key = '.'.join('+'.join(key.get(i, ''))
                               for i in val_msg._dim_ids)
```
So, when requesting data, the dataflow endpoint needs to be visited and it's impossible to do it specifying only one resource_id, at least in the ISTAT web service case.

I know this is not a solution, and I'm not asking to merge this in any way. Since I know very little of SDMX and of pandasdmx, and it seems that ISTAT has no interest in python, I'm wondering if there's a cleaner way to do this.