### PR TITLE
Improvements to model.ItemScheme, fix pydantic compat issues in util

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
 
-cache: pip
-
 python:
-  - "3.7"
-  - "3.7-dev"
+  - "3.7.4"
+  - "3.8-dev"
 
 dist: xenial
 
@@ -15,8 +13,7 @@ install:
 
 script: >
   pytest
-  --verbose 
-  -ra
+  -rfE
   --cov pandasdmx --cov-report term-missing
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,13 @@ python:
 dist: xenial
 
 install:
+  - pip install -U pip
   - pip install -r requirements.txt
   - pip install -e .[cache,docs,tests]
 
 script: >
   pytest
-  --verbose --remote-data
+  --verbose 
   -ra
   --cov pandasdmx --cov-report term-missing
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 
 python:
   - "3.7.4"
-  - "3.8-dev"
-
-dist: xenial
 
 install:
   - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 script: >
   pytest
   -rfE
+  --remote-data
   --cov pandasdmx --cov-report term-missing
 
 after_success:

--- a/pandasdmx/message.py
+++ b/pandasdmx/message.py
@@ -105,7 +105,7 @@ class StructureMessage(Message):
 
         # StructureMessage contents
         for attr in self.__dict__.values():
-            if attr and isinstance(attr, DictLike):
+            if isinstance(attr, DictLike) and len(attr):
                 lines.append(summarize_dictlike(attr))
 
         return '\n  '.join(lines)

--- a/pandasdmx/message.py
+++ b/pandasdmx/message.py
@@ -104,11 +104,9 @@ class StructureMessage(Message):
         lines = [super().__repr__()]
 
         # StructureMessage contents
-        for name in dir(self):
-            attr = getattr(self, name)
-            if not isinstance(attr, DictLike) or len(attr) == 0:
-                continue
-            lines.append(summarize_dictlike(attr))
+        for attr in self.__dict__.values():
+            if attr and isinstance(attr, DictLike):
+                lines.append(summarize_dictlike(attr))
 
         return '\n  '.join(lines)
 
@@ -134,7 +132,7 @@ class DataMessage(Message):
         lines = [super().__repr__()]
 
         # DataMessage contents
-        if len(self.data):
+        if self.data:
             lines.append('DataSet ({})'.format(len(self.data)))
         lines.extend(_summarize(self, ('dataflow', 'observation_dimension')))
 

--- a/pandasdmx/message.py
+++ b/pandasdmx/message.py
@@ -105,7 +105,7 @@ class StructureMessage(Message):
 
         # StructureMessage contents
         for attr in self.__dict__.values():
-            if isinstance(attr, DictLike) and len(attr):
+            if isinstance(attr, DictLike) and attr:
                 lines.append(summarize_dictlike(attr))
 
         return '\n  '.join(lines)

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -118,12 +118,9 @@ class InternationalString:
     # Duplicate of __getitem__, to pass existing tests in test_dsd.py
     def __getattr__(self, name):
         try:
-            return super().__getattr__(name)
-        except AttributeError:
-            try:
-                return self.__dict__['localizations'][name]
-            except KeyError:
-                raise AttributeError(name)
+            return self.__dict__['localizations'][name]
+        except KeyError:
+            raise AttributeError(name)
 
     def __add__(self, other):
         result = copy(self)
@@ -322,11 +319,8 @@ class ItemScheme(MaintainableArtefact):
 
     # Convenience access to items
     def __getattr__(self, name):
-        try:
-            return super().__getattr__(name)
-        except AttributeError:
-            # Provided to pass test_dsd.py
-            return self.__getitem__(name)
+        # Provided to pass test_dsd.py
+        return self.__getitem__(name)
 
     def __getitem__(self, name):
         for i in self.items:
@@ -1039,12 +1033,9 @@ class Key(BaseModel):
     # Convenience access to values by attribute
     def __getattr__(self, name):
         try:
-            return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return self.__getitem__(name)
-            except KeyError:
-                raise e
+            return self.__getitem__(name)
+        except KeyError as e:
+            raise e
 
     # Copying
     def __copy__(self):

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -329,10 +329,10 @@ class ItemScheme(MaintainableArtefact):
         raise KeyError(name)
 
     def __contains__(self, item):
-        """Recursive containment."""
-        for i in self.items:
-            if item == i or item in i:
-                return True
+        """Check containment. No recursive
+        search on children is performed as 
+        these are assumed to be items themselves."""
+        return item in self.items
 
     def __repr__(self):
         return "<{}: '{}', {} items>".format(

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -342,6 +342,9 @@ class ItemScheme(MaintainableArtefact):
             return item in self.items
         return item in self.items.values()
 
+    def __iter__(self):
+        return iter(self.items.values())
+    
     def extend(self, items: Iterable[_item_type]):
         self.items.update({i.id : i for i in items})
         
@@ -368,8 +371,7 @@ class ItemScheme(MaintainableArtefact):
             if isinstance(parent, str):
                 kwargs['parent'] = self[parent]
 
-            # Instantiate an object of the correct class by introspecting
-            # the items hint
+            # Instantiate an object of the correct class 
             obj = self._item_type(**kwargs)
 
         if obj not in self.items.values():

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -315,6 +315,25 @@ Item.update_forward_refs()
 
 
 class ItemScheme(MaintainableArtefact):
+    '''
+    This class implements the IM class of the same name.
+    Callers should use the below methods rather than 
+    access the ìtems`attribute. The latter is currently a dict. But this
+    may change in future versions. . Items can be accessed via their ìd`attribute as
+    specified in the IM.
+    Both item and attribute
+    syntax is supported as well as iteration over the items.
+    Items can be added in a list-like fashion using :meth:`append`and :meth:`extend``.
+    
+    TODO:
+     
+    * delete method for items 
+    * allow :meth:`extend`to be passed an 
+      ItemScheme instance or subclass
+    * verify field validation for subclasses (validation may currently be
+      limited to ItemScheme rather than the subclass)
+    * add sorting feature, e.g., when new items have been inserted
+    '''
     is_partial: Optional[bool]
     _item_type = Item
     items: Dict[str, _item_type] = {}

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -33,6 +33,7 @@ from operator import attrgetter
 from typing import (
     Any,
     Dict,
+    Iterable,
     List,
     Optional,
     Set,
@@ -316,7 +317,7 @@ Item.update_forward_refs()
 class ItemScheme(MaintainableArtefact):
     is_partial: Optional[bool]
     _item_type = Item
-    items: Dict[str, _item_type] = []
+    items: Dict[str, _item_type] = {}
 
     @validator('items', pre=True, whole=True)
     def convert_to_dict(cls, v):
@@ -341,6 +342,10 @@ class ItemScheme(MaintainableArtefact):
             return item in self.items
         return item in self.items.values()
 
+    def extend(self, items: Iterable[_item_type]):
+        self.items.update({i.id : i for i in items})
+        
+        
     def __repr__(self):
         return "<{}: '{}', {} items>".format(
             self.__class__.__name__,
@@ -423,7 +428,7 @@ class Concept(Item):
 
 class ConceptScheme(ItemScheme):
     _item_type = Concept
-    items: Dict[str, _item_type] = []
+    items: Dict[str, _item_type] = {} 
 
 
 
@@ -500,7 +505,7 @@ class Code(Item):
 
 class Codelist(ItemScheme):
     _item_type = Code
-    items: Dict[str, _item_type] = []
+    items: Dict[str, _item_type] = {}
 
 
 # 4.5: Category Scheme
@@ -511,7 +516,7 @@ class Category(Item):
 
 class CategoryScheme(ItemScheme):
     _item_type = Category
-    items: Dict[str, _item_type] = []
+    items: Dict[str, _item_type] = {}
 
 
 class Categorisation(MaintainableArtefact):
@@ -562,13 +567,13 @@ for cls in list(locals().values()):
 
 class AgencyScheme(ItemScheme):
     _item_type = Agency
-    items: Dict[str, _item_type] = []
+    items: Dict[str, _item_type] = {}
 
 
 
 class DataProviderScheme(ItemScheme):
     _item_type = DataProvider
-    items: Dict[str, _item_type] = []
+    items: Dict[str, _item_type] = {}
 
 
 # 10.2: Constraint inheritance

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -348,6 +348,11 @@ class ItemScheme(MaintainableArtefact):
     def extend(self, items: Iterable[_item_type]):
         self.items.update({i.id : i for i in items})
         
+    def __len__(self):
+        return len(self.items)
+        
+    def append(self, item):
+        self.items[item.id] = item
         
     def __repr__(self):
         return "<{}: '{}', {} items>".format(
@@ -806,7 +811,7 @@ class DimensionDescriptor(ComponentList):
         dd = cls()
         for id, kv in key.values.items():
             cl = Codelist(id=id)
-            cl.items.append(Code(id=kv.value))
+            cl.append(Code(id=kv.value))
             d = Dimension(id=id,
                           local_representation=Representation(enumerated=cl))
             dd.components.append(d)
@@ -919,7 +924,7 @@ class DataStructureDefinition(Structure, ConstrainableArtefact):
         dd = DimensionDescriptor.from_key(next(iter_keys))
         for k in iter_keys:
             for i, (id, kv) in enumerate(k.values.items()):
-                dd[i].local_representation.enumerated.items.append(
+                dd[i].local_representation.enumerated.append(
                     Code(id=kv.value))
         return cls(dimensions=dd)
 

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -1006,7 +1006,13 @@ class Reader(BaseReader):
     def parse_orgscheme(self, elem):
         cls = globals()[QName(elem).localname]
         os, values = self._named(cls, elem, unwrap=False)
-        os.extend(values.values())
+        # Get the list of organisations. The following 
+        # assumes that the `values`dict has only one item.
+        # Otherwise, the returned item will be unpredictable.
+        # TODO: Review the code parsing the children to
+        # verify that the assumption always holds. 
+        _, orgs = values.popitem()
+        os.extend(orgs)
         return os
 
     def parse_conceptscheme(self, elem):

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -973,13 +973,13 @@ class Reader(BaseReader):
 
     def parse_categoryscheme(self, elem):
         cs, values = self._named(CategoryScheme, elem)
-        cs.items.extend(values.pop('category', []))
+        cs.extend(values.pop('category', []))
         assert len(values) == 0
         return cs
 
     def parse_codelist(self, elem):
         cl, values = self._named(Codelist, elem, unwrap=False)
-        cl.items.extend(values.pop('code', []))
+        cl.extend(values.pop('code', []))
         assert len(values) == 0
         return cl
 
@@ -1006,13 +1006,12 @@ class Reader(BaseReader):
     def parse_orgscheme(self, elem):
         cls = globals()[QName(elem).localname]
         os, values = self._named(cls, elem, unwrap=False)
-        _, os.items = values.popitem()
-        assert len(values) == 0
+        os.extend(values.values())
         return os
 
     def parse_conceptscheme(self, elem):
         cs, values = self._named(ConceptScheme, elem, unwrap=False)
-        cs.items = values.pop('concept', [])
+        cs.extend(values.pop('concept', []))
         assert len(values) == 0
         return cs
 

--- a/pandasdmx/util.py
+++ b/pandasdmx/util.py
@@ -181,7 +181,7 @@ class DictLike(OrderedDict[KT, VT]):
         result, error = field._apply_validators(
             value, validators=field.validators, values={}, loc=(), cls=None)
         if error:
-            raise ValidationError([error])
+            raise ValidationError([error], self.__class__)
         else:
             return result
 

--- a/pandasdmx/util.py
+++ b/pandasdmx/util.py
@@ -123,7 +123,7 @@ class BaseModel(pydantic.BaseModel):
             value_, error_ = self.fields[name].validate(value, self.dict(**kw),
                                                         loc=name)
             if error_:
-                raise ValidationError([error_])
+                raise ValidationError([error_], self.__class__)
             else:
                 self.__values__[name] = value_
                 self.__fields_set__.add(name)

--- a/pandasdmx/util.py
+++ b/pandasdmx/util.py
@@ -125,10 +125,10 @@ class BaseModel(pydantic.BaseModel):
             if error_:
                 raise ValidationError([error_], self.__class__)
             else:
-                self.__values__[name] = value_
+                self.__dict__[name] = value_
                 self.__fields_set__.add(name)
         else:
-            self.__values__[name] = value
+            self.__dict__[name] = value
             self.__fields_set__.add(name)
 
 

--- a/pandasdmx/writer.py
+++ b/pandasdmx/writer.py
@@ -312,7 +312,7 @@ def write_itemscheme(obj, locale=DEFAULT_LOCALE):
         for child in item.child:
             add_item(child)
 
-    for item in obj.items:
+    for item in obj:
         add_item(item)
 
     # Convert to DataFrame

--- a/setup.py
+++ b/setup.py
@@ -4,22 +4,22 @@ from setuptools import find_packages, setup
 INSTALL_REQUIRES = [
     'lxml>=3.6',
     'pandas>=0.20',
-    'pydantic>=0.31',
+    'pydantic>=0.32.2',
     'requests>=2.7',
     'setuptools>19',
-    ]
+]
 
 TESTS_REQUIRE = [
     'pytest>=3.3',
     'pytest-remotedata>=0.3.1',
     'requests-mock>=1.4',
-    ]
+]
 
 EXTRAS_REQUIRE = {
     'cache': ['requests_cache'],
     'docs': ['sphinx>=1.5', 'ipython'],
     'tests': TESTS_REQUIRE,
-    }
+}
 
 setup(name='pandaSDMX',
       version='1.0b1',
@@ -47,5 +47,5 @@ setup(name='pandaSDMX',
           'Programming Language :: Python :: 3.7',
           'Topic :: Scientific/Engineering',
           'Topic :: Scientific/Engineering :: Information Analysis'
-          ]
+      ]
       )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -115,7 +115,7 @@ def test_request_preview_data():
     assert isinstance(keys, list)
 
     # Count of keys can be determined
-    assert len(keys) == 4291
+    assert len(keys) == 4331
 
     # A filter can be provided, resulting in fewer keys
     keys = req.preview_data('EXR', {'CURRENCY': 'CAD+CHF+CNY'})

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -221,6 +221,8 @@ class TestISTAT(DataSourceTest):
     @pytest.mark.remote_data
     def test_gh_75(self, req):
         """Test of https://github.com/dr-leo/pandaSDMX/pull/75."""
+        # Remove the following line after fixing Travis builds. 
+        pytest.skip(reason='Try to localize the cause for errored Travis builds.')
 
         df_id = '47_850'
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -221,8 +221,6 @@ class TestISTAT(DataSourceTest):
     @pytest.mark.remote_data
     def test_gh_75(self, req):
         """Test of https://github.com/dr-leo/pandaSDMX/pull/75."""
-        # Remove the following line after fixing Travis builds. 
-        pytest.skip(reason='Try to localize the cause for errored Travis builds.')
 
         df_id = '47_850'
 


### PR DESCRIPTION
This PR does the following:

1. On ItemScheme:
1.1 do not search children when iterating over items as children should be items themselves. This is at least how I understand the IM.

1.2 Make __getattrib__ more efficient by removing the redundant try... except clause.

2. Make test Suite pass again (relates to #106)

Travis builds errored as the build log size of 4M was exceeded. When omitting the remote_data Tests, two Tests still failed. This has been fixed by updating util.py according to a subtle Change in pydantic 32.2. Since, it is required to pass the model to ValidationError. This Change is not marked as code-braking as it is not part of the public API. Copying internal Code fom pydantic into pandasdmx makes the latter vulnerabnle to code-breaking changes in the pydantic internals. So we should think about alternatives such as not validating Item.child etc. 

I have also streamlined travis.yml. Remote-data Tests remain to be looked at. On my way I've decided not to test with py3.8 yet. But this is a TODO for the coming weeks.

I think this PR can be merged despite the constrained test Suite. It is more important to make Progress. And the next changes to the core do not require remote data to test. Still, I see merit in reconsidering the remote-data Tests for the travis builds in the medium term. I cannot even exclude that they would work as is. But this is not a priority for me.

