### PR TITLE
Fixed annotation issues and empty assignmentStatus in attributes

### DIFF
--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -26,6 +26,7 @@ Details of the implementation:
 #   - Guess URNs using the standard format.
 
 from copy import copy
+from collections.abc import Collection, Iterable as IterableABC
 from datetime import date, datetime, timedelta
 from enum import Enum
 from inspect import isclass
@@ -98,13 +99,22 @@ class InternationalString:
     def __init__(self, value=None, **kwargs):
         super().__init__()
 
+        # Handle initial values according to type
         if isinstance(value, str):
+            # Bare string
             value = {DEFAULT_LOCALE: value}
-        elif isinstance(value, tuple) and len(value) == 2:
+        elif (isinstance(value, Collection) and len(value) == 2
+              and isinstance(value[0], str)):
+            # 2-tuple of str is (locale, label)
             value = {value[0]: value[1]}
+        elif isinstance(value, IterableABC):
+            # Iterable of 2-tuples
+            value = {locale: label for (locale, label) in value}
         elif value is None:
+            # Keyword arguments → dict, possibly empty
             value = dict(kwargs)
         elif isinstance(value, dict):
+            # dict; use directly
             pass
         else:
             raise ValueError(value, kwargs)
@@ -154,18 +164,17 @@ class InternationalString:
 
     @classmethod
     def __validate(cls, value, values, config, field):
+        # Any value that the constructor can handle can be assigned
         if not isinstance(value, InternationalString):
             value = InternationalString(value)
 
-        # Maybe update existing value
         try:
+            # Update existing value
             existing = values[field.name]
-        except KeyError:
-            existing = None
-        if isinstance(existing, InternationalString):
             existing.localizations.update(value.localizations)
             return existing
-        else:
+        except KeyError:
+            # No existing value/None; return the assigned value
             return value
 
 

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -941,9 +941,9 @@ class Reader(BaseReader):
         values = self._parse(elem)
 
         # Rename values from child elements: 'annotationurl' → 'url'
-        for attr in ('text', 'title', 'type', 'url'):
+        for tag in ('text', 'title', 'type', 'url'):
             try:
-                values[attr] = values.pop('annotation' + attr)
+                values[tag] = values.pop('annotation' + tag)
             except KeyError:
                 pass
 

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -1088,12 +1088,12 @@ class Reader(BaseReader):
     def parse_attribute(self, elem):
         attrs = {k: elem.attrib[k] for k in ('id', 'urn')}
         elem_assgn_status = elem.attrib['assignmentStatus'].lower()
-        # map an empty attribute value from the xml to conditional
-        if (elem_assgn_status == ""):
-            attrs['usage_status'] = UsageStatus["conditional"]
-        else:
-            attrs['usage_status'] = UsageStatus[elem_assgn_status]
-        
+        try:
+            attrs['usage_status'] = UsageStatus[
+                                    elem.attrib['assignmentStatus'].lower()]
+        except KeyError:
+            pass
+
         values = self._parse(elem)
         da = DataAttribute(
             concept_identity=values.pop('conceptidentity'),

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -1087,7 +1087,6 @@ class Reader(BaseReader):
 
     def parse_attribute(self, elem):
         attrs = {k: elem.attrib[k] for k in ('id', 'urn')}
-        elem_assgn_status = elem.attrib['assignmentStatus'].lower()
         try:
             attrs['usage_status'] = UsageStatus[
                                     elem.attrib['assignmentStatus'].lower()]

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -939,18 +939,20 @@ class Reader(BaseReader):
 
     def parse_annotation(self, elem):
         values = self._parse(elem)
-        for attr in ('text', 'title', 'type', 'url', 'id'):
+
+        # Rename values from child elements: 'annotationurl' → 'url'
+        for attr in ('text', 'title', 'type', 'url'):
             try:
-                if attr == "id":
-                    values[attr] = elem.attrib['id']
-                else:
-                    values[attr] = values.pop('annotation' + attr)
-                # turn into a dict in case of multiples of the same tag
-                # ex. Multiple AnnotationText tags for different langs
-                if (type(values[attr]) == list):
-                   values[attr] = dict(values[attr])
+                values[attr] = values.pop('annotation' + attr)
             except KeyError:
                 pass
+
+        # Optional 'id' attribute
+        try:
+            values['id'] = elem.attrib['id']
+        except KeyError:
+            pass
+
         return Annotation(**values)
 
     def parse_code(self, elem):

--- a/tests/data/common/common.xml
+++ b/tests/data/common/common.xml
@@ -47,7 +47,7 @@
             <common:Description xml:lang="en">It provides a list of values indicating the "frequency" of the data (e.g. monthly) and, thus, indirectly, also implying the type of "time reference" that could be used for identifying the data with respect time.</common:Description>
             <structure:Code id="A">
                <common:Annotations>
-                  <common:Annotation>
+                  <common:Annotation id="A1">
                      <common:AnnotationType>NOTE</common:AnnotationType>
                      <common:AnnotationText xml:lang="en">It is typically used for annual data. This can also serve cases of multi-annual data (data that appear once every two, three or, possibly, five years). Descriptive information on the multiannual characteristics (e.g. frequency of the series in practice and other methodological information can be provided at the dataflow level, as long as these characteristics are applicable for the entire dataflow).</common:AnnotationText>
                   </common:Annotation>
@@ -56,9 +56,10 @@
             </structure:Code>
             <structure:Code id="B">
                <common:Annotations>
-                  <common:Annotation>
+                  <common:Annotation id="B1">
                      <common:AnnotationType>NOTE</common:AnnotationType>
                      <common:AnnotationText xml:lang="en">Similar to "daily", however there are no observations for Saturday and Sunday (so, neither "missing values" nor "numeric values" should be provided for Saturday and Sunday). This treatment ("business") is one way to deal with such cases, but it is not the only option. Such a time series could alternatively be considered daily ("D"), thus, with missing values in the weekend.</common:AnnotationText>
+                     <common:AnnotationText xml:lang="fr">Semblable à "quotidiennement", il n'y a cependant aucune observation pour le samedi et le dimanche (donc, ni "valeurs manquantes" ni "valeurs numériques" ne doivent être fournies pour le samedi et le dimanche). Ce traitement («entreprise») est une façon de traiter de tels cas, mais ce n'est pas la seule option. Une telle série chronologique pourrait alternativement être considérée quotidiennement ("D"), ainsi, avec des valeurs manquantes le week-end.</common:AnnotationText>
                   </common:Annotation>
                </common:Annotations>
                <common:Name>Daily - business week</common:Name>

--- a/tests/data/common/unsd_codelist_partial.xml
+++ b/tests/data/common/unsd_codelist_partial.xml
@@ -21,6 +21,7 @@
             <Annotation>
               <AnnotationTitle>PresentationTitle</AnnotationTitle>
               <AnnotationText xml:lang="en">Total</AnnotationText>
+              <AnnotationText xml:lang="fr">Total</AnnotationText>
             </Annotation>
           </Annotations>
           <Name xml:lang="en" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">All age ranges or no breakdown by age</Name>

--- a/tests/data/common/unsd_codelist_partial.xml
+++ b/tests/data/common/unsd_codelist_partial.xml
@@ -18,7 +18,7 @@
         </Code>
         <Code id="000_099_Y" urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=UNSD:CL_AGE_GROUP_SDG(1.0).000_099_Y">
           <Annotations xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
-            <Annotation>
+            <Annotation id="A1">
               <AnnotationTitle>PresentationTitle</AnnotationTitle>
               <AnnotationText xml:lang="en">Total</AnnotationText>
               <AnnotationText xml:lang="fr">Total</AnnotationText>

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -108,6 +108,13 @@ def test_internationalstring():
     i3 = Item(id='ECB', name={})
     assert i3.name.localizations == Item(id='ECB').name.localizations
 
+    # Create with iterable of 2-tuples
+    i4 = Item(id='ECB', name=[
+        ('DE', 'Europäische Zentralbank'),
+        ('FR', 'Banque centrale européenne'),
+    ])
+    assert i4.name['FR'] == 'Banque centrale européenne'
+
 
 def test_item():
     items = []


### PR DESCRIPTION
Hi, I was using pandaSDMX 1.0b to work with SDMXML files from Statistics Canada. The source xml file that I used can be downloaded [here](https://www150.statcan.gc.ca/n1/tbl/sdmx/36100472-SDMX.zip) I noticed these small issues that I think should not break anything else:

Fixes for a slightly overlooked Annotation object. 
1. The id was not being populated because its missing from the attr iteration tuple.
2. In my case the file had multiple AnnotationText tags that was a raising a validation error from pydantic(same for 0.32.x and 1.x). I figured out that converting the value in that case was a list of tuples like so: [(locale, string)]. I decided to do a list type check for when to type cast to dict, instead of an isolated check for only AnnotationText tags. 

Attribute assignmentStatus breaking entire parse when empty
In the file, I also saw that StatsCan filled in mandatory as the attribute value when it was so, but left in blank in non-mandatory scenarios, hence i decided to map it to conditional.

If there is a better was to go around fixing those issues please let me know and i would be happy to revise. =)
