### PR TITLE
Do not close tempfile for windows compat. Concerns ESTAT-provided zip…

### DIFF
--- a/pandasdmx/api.py
+++ b/pandasdmx/api.py
@@ -388,8 +388,7 @@ class Request:
                 raise
 
         # Maybe copy the response to file as it's received
-        arg = [tofile] if tofile else [] # explain or remove this. Why wrap in list and unpack it in next line?
-        response_content = remote.ResponseIO(response, *arg)
+        response_content = remote.ResponseIO(response, tee=tofile)
 
         # Select reader class
         content_type = response.headers.get('content-type', None)

--- a/pandasdmx/api.py
+++ b/pandasdmx/api.py
@@ -277,8 +277,8 @@ class Request:
             Type of resource to retrieve.
         resource_id : str, optional
             ID of the resource to retrieve.
-        tofile : str or :class:`~os.PathLike`, optional
-            File path to write SDMX data as it is recieved.
+        tofile : str or :class:`~os.PathLike` or `file-like object`, optional
+            File path or file-like to write SDMX data as it is recieved.
         use_cache : bool, optional
             If :obj:`True`, return a previously retrieved :class:`~.Message`
             from :attr:`cache`, or update the cache with a newly-retrieved
@@ -388,7 +388,7 @@ class Request:
                 raise
 
         # Maybe copy the response to file as it's received
-        arg = [tofile] if tofile else []
+        arg = [tofile] if tofile else [] # explain or remove this. Why wrap in list and unpack it in next line?
         response_content = remote.ResponseIO(response, *arg)
 
         # Select reader class

--- a/pandasdmx/remote.py
+++ b/pandasdmx/remote.py
@@ -92,7 +92,7 @@ class ResponseIO(BufferedIOBase):
 
         If the argument is omitted, :py:obj:`None`, or negative, reads and
         returns all data until EOF. If *tee* was provided to the constructor,
-        data is echoed to file. file is not closed.
+        data is echoed to file; *tee* is not closed.
 
         If the argument is positive, and the underlying raw stream is not
         ‘interactive’, multiple raw reads may be issued to satisfy the byte

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -260,7 +260,8 @@ class TestINSEE(DataSourceTest):
         req.get(endpoint, provider='all',
                 tofile=self._cache_path.with_suffix('.' + endpoint))
 
-
+@pytest.mark.xfail(reason='Service is currently unavailable.',
+                   raises=HTTPError)
 class TestISTAT(DataSourceTest):
     source_id = 'ISTAT'
 


### PR DESCRIPTION
Triggers follow-up changes in api and estat.py.

`tofile`arg in api.Reqest.get can now also be file-like. 

Closes #128

remote.ResponseIO.read never closes the generated file as this breaks on Windows. See