### PR TITLE
Handle Facet endValue; test individual XML elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ doc/_build
 prof/
 tests/data/cache
 htmlcov
+
+# Editors
 .vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ doc/_build
 prof/
 tests/data/cache
 htmlcov
+.vscode/settings.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 script: >
   pytest
   -rfE
+  --verbose
   --remote-data
   --cov pandasdmx --cov-report term-missing
 

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -1158,21 +1158,18 @@ class Reader(BaseReader):
         return r
 
     def parse_facet(self, elem):
-        f = Facet()
-
-        # Parse facet value type
-        # The following handles xml nodes tagged 'TextFormat' 
-        # TODO: Check if EnumerationFormat is properly handled? '. 
-        # In SDMXML, textType defaults to String.
+        # Parse facet value type; SDMX-ML default is 'String'
         fvt = elem.attrib.get('textType', 'String')
         # Convert case of the value. In XML, first letter is uppercase; in
         # the spec and Python enum, lowercase.
-        f.value_type = FacetValueType[fvt[0].lower() + fvt[1:]]
+        f = Facet(value_type=FacetValueType[fvt[0].lower() + fvt[1:]])
+
         # Other attributes are for Facet.type, an instance of FacetType
         for key, value in elem.attrib.items():
-            if key != 'textType':  
-                # Convert attribute name from camelCase to snake_case
-                setattr(f.type, to_snake(key), value)
+            if key == 'textType':
+                continue
+            # Convert attribute name from camelCase to snake_case
+            setattr(f.type, to_snake(key), value)
 
         return f
 

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -507,23 +507,19 @@ class Reader(BaseReader):
         """
         # Apply conversions to attributes
         convert_attrs = {
-            'agencyID': ('maintainer', lambda value: Agency(id=value)),
-            'isExternalReference': ('is_external_reference', bool),
-            'isFinal': ('is_final', bool),
-            'isPartial': ('is_partial', bool),
-            'structureURL': ('structure_url', lambda value: value),
+            'agency_id': ('maintainer', lambda value: Agency(id=value)),
             'role': ('role', lambda value:
                      ConstraintRole(role=ConstraintRoleType[value])),
-            'validFrom': ('valid_from', str),
-            'validTo': ('valid_to', str),
             }
 
-        attr = copy(elem.attrib)
-        for source, (target, xform) in convert_attrs.items():
-            try:
-                attr[target] = xform(attr.pop(source))
-            except KeyError:
-                continue
+        attr = {}
+        for name, value in elem.attrib.items():
+            # Name in snake case
+            name = to_snake(name)
+            # Optional new name and function to transform the value
+            (name, xform) = convert_attrs.get(name, (name, lambda v: v))
+            # Store transformed value
+            attr[name] = xform(value)
 
         try:
             # Maybe retrieve an existing reference

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -1208,15 +1208,9 @@ class Reader(BaseReader):
         if isinstance(value_type, str):
             value_type = FacetValueType[value_type[0].lower() + value_type[1:]]
         f = Facet(value_type=value_type)
-        key_map = {
-            'isSequence': 'is_sequence',
-            'minValue': 'min_value',
-            'maxValue': 'max_value',
-            'minLength': 'min_length',
-            'maxLength': 'max_length',
-            }
         for key, value in attr.items():
-            setattr(f.type, key_map.get(key, key), value)
+            # Convert attribute name from camelCase to snake_case
+            setattr(f.type, re.sub('([A-Z]+)', r'_\1', key).lower(), value)
         return f
 
     # Parsers for constraints etc.

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -1158,24 +1158,21 @@ class Reader(BaseReader):
         return r
 
     def parse_facet(self, elem):
-        attr = copy(elem.attrib)
         f = Facet()
 
         # Parse facet value type
-        try:
-            fvt = attr.pop('textType')
-        except KeyError:
-            # No such attribute
-            pass
-        else:
-            # Convert case of the value. In XML, first letter is uppercase; in
-            # the spec and Python enum, lowercase.
-            f.value_type = FacetValueType[fvt[0].lower() + fvt[1:]]
-
-        # Remaining attributes are for Facet.type, an instance of FacetType
-        for key, value in attr.items():
-            # Convert attribute name from camelCase to snake_case
-            setattr(f.type, to_snake(key), value)
+        # The following handles xml nodes tagged 'TextFormat' 
+        # TODO: Check if EnumerationFormat is properly handled? '. 
+        # In SDMXML, textType defaults to String.
+        fvt = elem.attrib.get('textType', 'String')
+        # Convert case of the value. In XML, first letter is uppercase; in
+        # the spec and Python enum, lowercase.
+        f.value_type = FacetValueType[fvt[0].lower() + fvt[1:]]
+        # Other attributes are for Facet.type, an instance of FacetType
+        for key, value in elem.attrib.items():
+            if key != 'textType':  
+                # Convert attribute name from camelCase to snake_case
+                setattr(f.type, to_snake(key), value)
 
         return f
 

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -450,8 +450,7 @@ class Reader(BaseReader):
                 # Current scope index for IdentifiableArtefacts
                 self._current[(item.__class__, item.id)] = item
 
-    def _maintained(self, cls=None, id=None, urn=None, match_subclass=False,
-                    **kwargs):
+    def _maintained(self, cls=None, id=None, urn=None, **kwargs):
         """Retrieve or instantiate a MaintainableArtefact of *cls* with *ids.
 
         If the object has been parsed (i.e. is in :attr:`_index`), it is
@@ -460,21 +459,11 @@ class Reader(BaseReader):
 
         If *urn* is given, it is used to determine *cls* and *id*, per the URN
         regular expression.
-
-        If *match_subclass* is False, *cls* may either be a string or a class
-        for a subclass of MaintainableArtefact. If *match_subclass* is True,
-        *cls* must be a class.
         """
         if urn:
             match = URN.match(urn).groupdict()
             cls = get_class(match['package'], match['class'])
             id = match['id']
-
-        if match_subclass:
-            for key, obj in self._index.items():
-                if isinstance(obj, cls) and obj.id == id:
-                    return obj
-            raise ValueError(cls, id)
 
         key = (cls.__name__, id) if isclass(cls) else (cls, id)
 
@@ -486,7 +475,8 @@ class Reader(BaseReader):
                 raise TypeError(f'{cls} is not maintainable')
 
             # Create a new object. A reference to a MaintainableArtefact that
-            # is not defined in the current message is, necessarily, external
+            # is not (yet) defined in the current message is, necessarily,
+            # external
             assert kwargs.pop('is_external_reference', True)
             self._index[key] = cls(id=id, is_external_reference=True,
                                    **kwargs)

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -11,65 +11,21 @@ from lxml.etree import QName, XPath
 
 from pandasdmx.exceptions import ParseError, XMLParseError
 from pandasdmx.message import (
-    DataMessage,
-    ErrorMessage,
-    Footer,
-    Header,
-    StructureMessage,
+    DataMessage, ErrorMessage, Footer, Header, StructureMessage,
     )
-from pandasdmx.model import (
-    DEFAULT_LOCALE,
-    Agency,
-    AgencyScheme,
-    AllDimensions,
-    Annotation,
-    AttributeDescriptor,
-    NoSpecifiedRelationship,
-    PrimaryMeasureRelationship,
-    DimensionRelationship,
-    AttributeValue,
-    Categorisation,
-    Category,
-    CategoryScheme,
-    Code,
-    Codelist,
-    ComponentValue,
-    Concept,
-    ConceptScheme,
-    Contact,
-    ContentConstraint,
-    ConstraintRole,
-    ConstraintRoleType,
-    CubeRegion,
-    DataAttribute,
-    DataflowDefinition,
-    DataKey,
-    DataKeySet,
-    DataProvider,
-    DataProviderScheme,
-    DataSet,
-    DataStructureDefinition,
-    Dimension,
-    DimensionDescriptor,
-    Facet,
-    FacetValueType,
-    GroupDimensionDescriptor,
-    GroupKey,
-    IdentifiableArtefact,
-    InternationalString,
-    ItemScheme,
-    MaintainableArtefact,
-    MeasureDescriptor,
-    MemberSelection,
-    MemberValue,
-    Key,
-    Observation,
-    PrimaryMeasure,
-    ProvisionAgreement,
-    Representation,
-    SeriesKey,
-    TimeDimension,
-    UsageStatus,
+from pandasdmx.model import (  # noqa: F401
+    DEFAULT_LOCALE, Agency, AgencyScheme, AllDimensions, Annotation,
+    AttributeDescriptor, NoSpecifiedRelationship, PrimaryMeasureRelationship,
+    DimensionRelationship, AttributeValue, Categorisation, Category,
+    CategoryScheme, Code, Codelist, ComponentValue, Concept, ConceptScheme,
+    Contact, ContentConstraint, ConstraintRole, ConstraintRoleType, CubeRegion,
+    DataAttribute, DataflowDefinition, DataKey, DataKeySet, DataProvider,
+    DataProviderScheme, DataSet, DataStructureDefinition, Dimension,
+    DimensionDescriptor, Facet, FacetValueType, GroupDimensionDescriptor,
+    GroupKey, IdentifiableArtefact, InternationalString, ItemScheme,
+    MaintainableArtefact, MeasureDescriptor, MeasureDimension, MemberSelection,
+    MemberValue, Key, Observation, PrimaryMeasure, ProvisionAgreement,
+    Representation, SeriesKey, TimeDimension, UsageStatus,
     )
 
 from pandasdmx.reader import BaseReader
@@ -182,6 +138,7 @@ METHOD = {
     'TextFormat': 'facet',
     'EnumerationFormat': 'facet',
 
+    'MeasureDimension': 'dimension',
     'TimeDimension': 'dimension',
 
     # Tags that are bare containers for other XML elements; skip entirely
@@ -1103,7 +1060,7 @@ class Reader(BaseReader):
     def parse_dimension(self, elem):
         values = self._parse(elem)
 
-        # Object class: Dimension, TimeDimension, etc.
+        # Object class: Dimension, MeasureDimension, or TimeDimension
         cls = globals()[QName(elem).localname]
 
         attr = copy(elem.attrib)

--- a/tests/test_reader_xml.py
+++ b/tests/test_reader_xml.py
@@ -1,6 +1,8 @@
 import warnings
 
+from lxml.etree import Element
 import pandasdmx as sdmx
+from pandasdmx.reader.sdmxml import Reader
 import pytest
 
 from . import test_data_path, test_files
@@ -72,3 +74,19 @@ def test_read_ss_xml():
     # navigating object relationships
     TIME_FORMAT = s0_key.attrib['TIME_FORMAT'].value_for
     assert len(TIME_FORMAT.related_to.dimensions) == 5
+
+
+@pytest.mark.parametrize('elem', [
+    # Reader.parse_facet
+    Element('Facet', isSequence='False', startValue='3.4', endValue='1'),
+])
+def test_parse_elem(elem):
+    """Test individual XML elements.
+
+    This method allows unit-level testing of specific XML elements appearing in
+    SDMX-ML messages. Add elements by extending the list passed to the
+    parametrize() decorator.
+    """
+    # Create a reader and parse just one element; test passes if no exception
+    # is raised
+    Reader()._parse(elem)


### PR DESCRIPTION
This PR:
- Adjusts sdmxml.Reader.parse_facet to handle all attributes of FacetType using a regex.
- Adds a general method for fast, atomic tests of parsing single XML elements.