### PR TITLE
Add rtype argument to to_pandas()

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,3 @@
-[report]
+[run]
 omit =
     pandasdmx/experimental.py
-    tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 .coverage
 .pytest_cache
 build
+coverage.xml
 dist
 doc/cache.sqlite
 doc/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 
 script: >
   pytest
-  -rfE
+  -ra
   --verbose
   --remote-data
   --cov pandasdmx --cov-report term-missing

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -82,6 +82,7 @@ SDMX-JSON
 
       .. autosummary::
          write_component
+         write_datamessage
          write_dataset
          write_dict
          write_dimensiondescriptor
@@ -92,10 +93,11 @@ SDMX-JSON
          write_serieskeys
          write_structuremessage
 
+.. autodata:: DEFAULT_RTYPE
+
 .. todo::
    Support selection of language for conversion of
    :class:`InternationalString <pandasdmx.model.InternationalString>`.
-
 
 
 ``remote``: Access SDMX REST web services

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -90,6 +90,57 @@ To display the categorised items, in our case the dataflow definitions contained
 .. versionadded:: 0.5
 
 
+.. _howto-rtype:
+
+Select data frame layouts returned by :func:`.to_pandas`
+--------------------------------------------------------
+
+:func:`.to_pandas` provides multiple ways to customize the type and layout of pandas objects returned for :class:`.DataMessage` input.
+One is the `datetime` argument; see :ref:`datetime`.
+The other is the `rtype` argument.
+
+To select the same behaviour as pandaSDMX 0.9, give `rtype` = 'compat'.
+This value is the default in pandaSDMX 1.0, but may change in a future version.
+With 'compat', the returned layout varies with the concept of “dimension at the observation level,” as follows:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Dimension At Observation Level
+     - Return Type
+   * - :data:`.AllDimensions`
+     - - :class:`~pandas.Series`, without attributes, or
+       - :class:`~pandas.DataFrame`, with any attributes.
+   * - :class:`.TimeDimension`
+     - Same as `datetime` = :obj:`True` —a :class:`~pandas.Dataframe` with:
+
+       - index: :class:`~pandas.DatetimeIndex` or :class:`~pandas.PeriodIndex`, and
+       - columns: :class:`~pandas.MultiIndex` with all other dimensions.
+   * - Other :class:`.Dimension`
+     - :class:`~pandas.DataFrame` with:
+
+       - index: the dimension at observation level, and
+       - columns: :class:`~pandas.MultiIndex` with all other dimensions.
+
+Limitations:
+
+- pandaSDMX can only obey `rtype` = 'compat' when reading or converting an entire :class:`.DataMessage`; not a :class:`.DataSet`.
+  While the concept of “dimension at observation level” is *mentioned* in the IM in relation to data sets, it is not formally included as an attribute of any class, or with any default value.
+  (For instance, it is not included in the :class:`.DimensionDescriptor` of a :class:`.DataStructureDefinition`.)
+  It can *only* be determined from the header of a SDMX-ML or -JSON data message.
+- Except for :data:`.AllDimensions`, each row and column of the returned data frame contains multiple observations, so attributes cannot be included without ambiguity about which observation(s) have the attribute.
+  In these cases, attributes are omitted; use `rtype` = 'rows' to retrieve them.
+
+With the argument `rtype` = 'rows', or by setting :data:`.DEFAULT_RTYPE` to 'rows':
+
+.. ipython:: python
+
+   sdmx.writer.DEFAULT_RYPE = 'rows'
+
+…data are *always* returned with one row per observation.
+
+
 .. _howto-convert:
 
 Convert SDMX data to other formats

--- a/pandasdmx/message.py
+++ b/pandasdmx/message.py
@@ -24,6 +24,7 @@ from pandasdmx.model import (
     DataflowDefinition,
     DataStructureDefinition,
     Dimension,
+    DimensionComponent,
     InternationalString,
     Item,
     ProvisionAgreement,
@@ -82,8 +83,6 @@ class Message(BaseModel):
     class Config:
         # for .response
         arbitrary_types_allowed = True
-        # NB this is required to prevent “unhashable type: 'dict'” in pydantic
-        validate_assignment = False
 
     #: :class:`Header` instance.
     header: Header = Header()
@@ -152,11 +151,9 @@ class DataMessage(Message):
     data: List[DataSet] = []
     #: :class:`.DataflowDefinition` that contains the data.
     dataflow: DataflowDefinition = DataflowDefinition()
-
-    # TODO infer the observation dimension from the DSD, e.g.
-    # - If a *TimeSeriesDataSet, it's the TimeDimension,
-    # - etc.
-    observation_dimension: Union[_AllDimensions, List[Dimension]] = None
+    #: The "dimension at observation level".
+    observation_dimension: Union[_AllDimensions, DimensionComponent,
+                                 List[DimensionComponent]] = None
 
     # Convenience access
     @property

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -1485,6 +1485,22 @@ class DataSet(AnnotableArtefact):
             return ActionType[value]
 
 
+class StructureSpecificDataSet(DataSet):
+    """SDMX-IM StructureSpecificDataSet."""
+
+
+class GenericDataSet(DataSet):
+    """SDMX-IM GenericDataSet."""
+
+
+class GenericTimeSeriesDataSet(DataSet):
+    """SDMX-IM GenericTimeSeriesDataSet."""
+
+
+class StructureSpecificTimeSeriesDataSet(DataSet):
+    """SDMX-IM StructureSpecificTimeSeriesDataSet."""
+
+
 class _AllDimensions:
     pass
 

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -558,11 +558,19 @@ class ComponentList(IdentifiableArtefact):
         """Append *value* to :attr:`components`."""
         self.components.append(value)
 
-    def get(self, id, **kwargs):
+    def get(self, id, cls=None, **kwargs):
         """Return or create the component with the given *id*.
 
-        The *kwargs* are passed to the constructor of Component(), or a
-        subclass if 'components' is overridden in a subclass of ComponentList.
+        Parameters
+        ----------
+        id : str
+            Component ID.
+        cls : type, optional
+            Hint for the class of a new object.
+        kwargs
+            Passed to the constructor of :class:`.Component`, or a Component
+            subclass if :attr:`.components` is overridden in a subclass of
+            ComponentList.
         """
         # TODO use an index to speed up
         # TODO don't return missing items or add an option to avoid this
@@ -572,14 +580,15 @@ class ComponentList(IdentifiableArtefact):
             if c.id == id:
                 return c
 
-        # No match. Chose an appropriate class specified for the attribute in
-        # the ComponentList subclass.
-        try:
-            klass = self._default_type
-        except AttributeError:
-            klass = get_class_hint(self, 'components')
+        # No match
 
-        component = klass(id=id, **kwargs)
+        # Create a new object of a class:
+        # 1. Given by the cls argument,
+        # 2. Specified by a subclass' _default_type attribute, or
+        # 3. Hinted for a subclass' components attribute.
+        cls = cls or getattr(self, '_default_type',
+                             get_class_hint(self, 'components'))
+        component = cls(id=id, **kwargs)
 
         if 'order' not in kwargs:
             # For automatically created dimensions, give a serial value to the

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -751,7 +751,11 @@ class Reader(BaseReader):
         self._add_to_index(indexables_from_dsd(dsd))
         self._current[(DataStructureDefinition, None)] = dsd
 
-        ds = DataSet(structured_by=dsd)
+        # DataSet class, e.g. GenericDataSet for root XML tag 'GenericData'
+        DataSetClass = getattr(pandasdmx.model, f'{self._stack[0]}Set')
+
+        # Create the object
+        ds = DataSetClass(structured_by=dsd)
 
         values = self._parse(elem, unwrap=False)
 

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -720,14 +720,18 @@ class Reader(BaseReader):
                                      structure=dsd)
             extra.append(dfd)
 
-            # Also store the dimension at observation
-            """Store the observation dimension for the current DataSet."""
+            # Store the observation at dimension level
             dim_at_obs = values.pop('dim_at_obs')
             if dim_at_obs == 'AllDimensions':
                 self._obs_dim = AllDimensions
             else:
                 # Retrieve or create the Dimension
-                self._obs_dim = dsd.dimensions.get(dim_at_obs, order=1e9)
+                args = dict(id=dim_at_obs, order=1e9)
+                if 'TimeSeries' in self._stack[0]:
+                    # {,StructureSpecific}TimeSeriesData message → the
+                    # dimension at observation level is a TimeDimension
+                    args['cls'] = TimeDimension
+                self._obs_dim = dsd.dimensions.get(**args)
 
         # Maybe return the DFD; see .initialize()
         return [Header(**values)] + extra

--- a/pandasdmx/tests/conftest.py
+++ b/pandasdmx/tests/conftest.py
@@ -1,6 +1,8 @@
 import logging
 
-import pandasdmx
+import pandasdmx as sdmx
 
 
-pandasdmx.logger.setLevel(logging.INFO)
+sdmx.logger.setLevel(logging.INFO)
+
+sdmx.writer.DEFAULT_RTYPE = 'rows'

--- a/pandasdmx/tests/test_compat.py
+++ b/pandasdmx/tests/test_compat.py
@@ -1,25 +1,15 @@
 import pandas as pd
-import pytest
 
 import pandasdmx as sdmx
 
 from .data import specimen
 
 
-@pytest.fixture(autouse=True)
-def compat_rtype():
-    """Ensure DEFAULT_RTYPE is 'compat' for all tests in this file."""
-    tmp = sdmx.writer.DEFAULT_RTYPE
-    sdmx.writer.DEFAULT_RTYPE = 'compat'
-    yield
-    sdmx.writer.DEFAULT_TYPE = tmp
-
-
 def pd_obj(name):
     """Return the specimen at *name* read, then converted to pandas."""
     with specimen(name) as f:
         data_msg = sdmx.read_sdmx(f)
-    return sdmx.to_pandas(data_msg)
+    return sdmx.to_pandas(data_msg, rtype='compat')
 
 
 def test_xml():

--- a/pandasdmx/tests/test_compat.py
+++ b/pandasdmx/tests/test_compat.py
@@ -1,0 +1,40 @@
+import pandas as pd
+import pytest
+
+import pandasdmx as sdmx
+
+from .data import specimen
+
+
+@pytest.fixture(autouse=True)
+def compat_rtype():
+    """Ensure DEFAULT_RTYPE is 'compat' for all tests in this file."""
+    tmp = sdmx.writer.DEFAULT_RTYPE
+    sdmx.writer.DEFAULT_RTYPE = 'compat'
+    yield
+    sdmx.writer.DEFAULT_TYPE = tmp
+
+
+def pd_obj(name):
+    """Return the specimen at *name* read, then converted to pandas."""
+    with specimen(name) as f:
+        data_msg = sdmx.read_sdmx(f)
+    return sdmx.to_pandas(data_msg)
+
+
+def test_xml():
+    """Test that objects have the expected layout with rtype='compat'."""
+    # GenericData with non-time Dimension at observation → data frame
+    df1 = pd_obj('ng-xs.xml')
+    assert isinstance(df1.index, pd.Index) and df1.index.name == 'CURRENCY'
+    assert isinstance(df1.columns, pd.MultiIndex)
+
+    # TimeSeriesData → data frame with DatetimeIndex
+    df2 = pd_obj('ng-ts.xml')
+    assert isinstance(df2.index, pd.DatetimeIndex)
+    assert isinstance(df2.columns, pd.MultiIndex)
+
+    # GenericData with AllDimensions at observation → series
+    df3 = pd_obj('ng-flat.xml')
+    assert isinstance(df3, pd.Series)
+    assert isinstance(df3.index, pd.MultiIndex)

--- a/pandasdmx/tests/test_docs.py
+++ b/pandasdmx/tests/test_docs.py
@@ -13,7 +13,7 @@ import pytest
 
 import pandasdmx as sdmx
 from pandasdmx import Request
-from pandasdmx.model import DataSet
+from pandasdmx.model import GenericDataSet
 from pandasdmx.util import DictLike
 
 from . import assert_pd_equal
@@ -165,7 +165,7 @@ def test_doc_usage_data():
     #                                  'endPeriod': '2016-12-31'})
     data = data_response.data[0]
 
-    assert type(data) is DataSet
+    assert type(data) is GenericDataSet
 
     # This message doesn't explicitly specify the remaining dimensions; unless
     # they are inferred from the SeriesKeys, then the DimensionDescriptor is

--- a/pandasdmx/tests/test_writer.py
+++ b/pandasdmx/tests/test_writer.py
@@ -1,8 +1,4 @@
 """Tests for pandasdmx/writer.py."""
-# TODO test all possible values of Writer.write() arguments
-# - attribute
-# …for each type of input argument.
-
 import pandas as pd
 import pytest
 from pytest import raises

--- a/pandasdmx/util.py
+++ b/pandasdmx/util.py
@@ -162,6 +162,7 @@ class BaseModel(pydantic.BaseModel):
 
 
 def get_class_hint(obj, attr):
+    """Return the type hint for attribute *attr* on *obj*."""
     klass = get_type_hints(obj.__class__)[attr].__args__[0]
     if getattr(klass, '__origin__', None) is Union:
         klass = klass.__args__[0]

--- a/pandasdmx/writer.py
+++ b/pandasdmx/writer.py
@@ -3,6 +3,7 @@ from itertools import chain
 import numpy as np
 import pandas as pd
 
+from pandasdmx import model
 from pandasdmx.model import (
     DEFAULT_LOCALE,
     AgencyScheme,
@@ -32,7 +33,7 @@ DEFAULT_RTYPE = 'compat'
 
 
 # Class → common write_*() methods
-_alias = {
+_ALIAS = {
     DictLike: dict,
     AgencyScheme: ItemScheme,
     CategoryScheme: ItemScheme,
@@ -42,6 +43,10 @@ _alias = {
     DataStructureDefinition: NameableArtefact,
     Dimension: Component,
     TimeDimension: Component,
+    model.GenericDataSet: DataSet,
+    model.GenericTimeSeriesDataSet: DataSet,
+    model.StructureSpecificDataSet: DataSet,
+    model.StructureSpecificTimeSeriesDataSet: DataSet,
 }
 
 
@@ -54,7 +59,7 @@ def write(obj, *args, **kwargs):
     behaviour, including accepted *args* and *kwargs*.
     """
     cls = obj.__class__
-    function = 'write_' + _alias.get(cls, cls).__name__.lower()
+    function = 'write_' + _ALIAS.get(cls, cls).__name__.lower()
     return globals()[function](obj, *args, **kwargs)
 
 

--- a/pandasdmx/writer.py
+++ b/pandasdmx/writer.py
@@ -128,7 +128,7 @@ def write_set(obj, *args, **kwargs):
 
 
 # Functions for message classes
-def write_datamessage(obj, *args, rtype=DEFAULT_RTYPE, **kwargs):
+def write_datamessage(obj, *args, rtype=None, **kwargs):
     """Convert :class:`.DataMessage`.
 
     The data set(s) within the message are converted to pandas objects.
@@ -136,7 +136,8 @@ def write_datamessage(obj, *args, rtype=DEFAULT_RTYPE, **kwargs):
     Parameters
     ----------
     rtype : 'compat' or 'rows', optional
-        Data type to return. See the :ref:`HOWTO <howto-rtype>`.
+        Data type to return; default :data:`.DEFAULT_RTYPE`. See the
+        :ref:`HOWTO <howto-rtype>`.
     kwargs :
         Passed to :meth:`write_dataset` for each data set.
 
@@ -151,8 +152,8 @@ def write_datamessage(obj, *args, rtype=DEFAULT_RTYPE, **kwargs):
     kwargs.setdefault('dsd', obj.dataflow.structure)
 
     # Pass the return type and associated information
-    kwargs['_rtype'] = rtype
-    if rtype == 'compat':
+    kwargs['_rtype'] = rtype or DEFAULT_RTYPE
+    if kwargs['_rtype'] == 'compat':
         kwargs['_message_class'] = obj.__class__
         kwargs['_observation_dimension'] = obj.observation_dimension
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,9 +63,8 @@ upload-dir = doc/build/html
 universal=1
 
 [tool:pytest]
-testpaths = pandasdmx/tests
-addopts = --cov pandasdmx
-    --cov-report html --cov-report term
+addopts = pandasdmx
+    --cov pandasdmx --cov-report=
     -m "not experimental"
 markers =
     experimental: experimental features


### PR DESCRIPTION
As discussed at https://github.com/dr-leo/pandaSDMX/issues/145#issuecomment-606684026.

- The first commit adds [documentation](https://github.com/dr-leo/pandaSDMX/pull/151/files#diff-dced552e02b8626b2866b678c3572ec8) to describe the behaviour.
- Remaining commits implement this behaviour.
- New file test_compat.py tests the desired behaviour: https://github.com/dr-leo/pandaSDMX/blob/792def35f6eb417d660ac0a92de1a8f1f08ec19b/pandasdmx/tests/test_compat.py#L15-L30