### PR TITLE
(Re-)enable IPython tab completion of Request convenience methods

### DIFF
--- a/pandasdmx/api.py
+++ b/pandasdmx/api.py
@@ -59,7 +59,20 @@ class Request:
 
     def __getattr__(self, name):
         """Convenience methods."""
-        return partial(self.get, Resource[name])
+        try:
+            # Provide resource_type as a positional argument, so that the
+            # first positional argument to the convenience method is treated as
+            # resource_id
+            func = partial(self.get, Resource[name])
+        except KeyError:
+            raise AttributeError
+        else:
+            # Modify the docstring to explain the argument fixed by the
+            # convenience method
+            func.__doc__ = self.get.__doc__.replace(
+                '.\n',
+                f' with resource_type={repr(name)}.\n', 1)
+            return func
 
     def __dir__(self):
         """Include convenience methods in dir()."""

--- a/pandasdmx/api.py
+++ b/pandasdmx/api.py
@@ -63,7 +63,7 @@ class Request:
 
     def __dir__(self):
         """Include convenience methods in dir()."""
-        return sorted(super().__dir__() + [ep.name for ep in Resource])
+        return super().__dir__() + [ep.name for ep in Resource]
 
     def clear_cache(self):
         self.cache.clear()


### PR DESCRIPTION
This works in the IPython console on my system:
```python
>>> import pandasdmx as sdmx
>>> ECB = sdmx.Request('ECB')
>>> ECB.co<tab>
```
…completes to `ECB.codelist`

Also improves the docstring:
```python
>>> ECB.codelist?
```
starts with the line "Retrieve SDMX data or metadata with resource_type='codelist'."
