### PR TITLE
Store URNs of MaintainableArtefacts and test

### DIFF
--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -478,12 +478,13 @@ class Reader(BaseReader):
             elif not issubclass(cls, MaintainableArtefact):
                 raise TypeError(f'{cls} is not maintainable')
 
-            # Create a new object. A reference to a MaintainableArtefact that
-            # is not (yet) defined in the current message is, necessarily,
-            # external
-            assert kwargs.pop('is_external_reference', True)
-            self._index[key] = cls(id=id, is_external_reference=True,
-                                   **kwargs)
+            # A reference to a MaintainableArtefact that is not (yet) defined
+            # in the current message is, necessarily, external, so finding
+            # is_external_reference=False in the kwargs is a fatal error here.
+            assert kwargs.setdefault('is_external_reference', True)
+
+            # Create a new object and add to index
+            self._index[key] = cls(id=id, **kwargs)
 
         # Existing or newly-created object
         return self._index[key]

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -466,6 +466,9 @@ class Reader(BaseReader):
             cls = get_class(match['package'], match['class'])
             id = match['id']
 
+            # Re-add the URN to the kwargs
+            kwargs['urn'] = urn
+
         key = (cls.__name__, id) if isclass(cls) else (cls, id)
 
         # Maybe create a new object

--- a/pandasdmx/tests/test_dsd.py
+++ b/pandasdmx/tests/test_dsd.py
@@ -37,7 +37,7 @@ class Test_ESTAT_dsd_apro_mk_cola(MessageTest):
 
         assert all(len(df) == count[id] for id, df in cls_as_dfs.items())
 
-    def test_dsd_urn(self, msg):
+    def test_urn(self, msg):
         """https://github.com/dr-leo/pandaSDMX/issue/154."""
         expected = ('urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure='
                     'ESTAT:DSD_apro_mk_cola(1.0)')
@@ -68,6 +68,17 @@ class TestDSDCommon(MessageTest):
         assert isinstance(a, model.Annotation)
         assert a.text.en.startswith('It is')
         assert a.type == 'NOTE'
+
+
+class TestECB_EXR1(MessageTest):
+    path = MessageTest.path / 'ECB_EXR' / '1'
+    filename = 'structure.xml'
+
+    def test_uri(self, msg):
+        """https://github.com/dr-leo/pandaSDMX/issue/154."""
+        expected = 'https://www.ecb.europa.eu/vocabulary/stats/exr/1'
+        # URI is parsed
+        assert msg.structure['ECB_EXR1'].uri == expected
 
 
 def test_exr_constraints():

--- a/pandasdmx/tests/test_dsd.py
+++ b/pandasdmx/tests/test_dsd.py
@@ -37,6 +37,14 @@ class Test_ESTAT_dsd_apro_mk_cola(MessageTest):
 
         assert all(len(df) == count[id] for id, df in cls_as_dfs.items())
 
+    def test_dsd_urn(self, msg):
+        """https://github.com/dr-leo/pandaSDMX/issue/154."""
+        expected = ('urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure='
+                    'ESTAT:DSD_apro_mk_cola(1.0)')
+
+        # URN is parsed
+        assert msg.structure.DSD_apro_mk_cola.urn == expected
+
 
 class TestDSDCommon(MessageTest):
     path = MessageTest.path / 'SGR'


### PR DESCRIPTION
This adds two tests, and one line of code: https://github.com/dr-leo/pandaSDMX/blob/f53ac118e69c888c4b6d2c1dde47c885b4d6b1de/pandasdmx/reader/sdmxml.py#L469-L470

If I *comment out* that line of code and run the tests (`pytest -k dsd`):
- `TestECB_EXR1.test_uri` **passes**, i.e. the code was already successfully storing URIs.
- `Test_ESTAT_dsd_apro_mk_cola.test_urn` **fails**, i.e. the test confirms that the URN was not being parsed, per #154.

The specimen used by TestECB_EXR1 is the only one in the entire collection of pandasdmx/tests/data/ that contains an XML URI attribute. @dr-leo your title for #154 says that "URN and URI attributes are None"; but the URI *should* be None if it doesn't appear in a message. To be clear, did you see an positive case where a URI *was* in the XML, but did *not* appear on the parsed object?

If so, please describe so it can be reproduced/checked here. If not, then this code resolves the issue.