### PR TITLE
Fallback to current scope search in sdmxml.Reader.parse_memberselection

### DIFF
--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -541,18 +541,27 @@ class Reader(BaseReader):
         # Return the instance and any non-name values
         return obj, values
 
-    def _get_current(self, cls):
-        """Return the sole instance of *cls* in the :attr:`_current` scope.
+    def _get_current(self, cls, id=None):
+        """Return an instance of *cls* in the :attr:`_current` scope.
 
-        Raises AssertionError if there are 0, or 2 or more instances.
+        *cls* may be a single class or tuple of classes valid as the
+        `classinfo` argument of :func:`issubclass`. If `id` is given, the
+        object must also have a matching ID.
+
+        Raises RuntimeError if there are 0, or 2 or more instances.
         """
         results = []
         for k, obj in self._current.items():
-            if k[0] is cls:
+            if issubclass(k[0], cls) and (id is None or id == k[1]):
                 results.append(obj)
 
-        assert len(results) == 1, results
-        return results[0]
+        if len(results) == 1:
+            return results[0]
+        elif len(results) > 1:  # pragma: no cover
+            raise RuntimeError(f'cannot disambiguate multiple {cls.__name__} '
+                               f'in the current scope: {results}')
+        else:  # pragma: no cover
+            raise RuntimeError(f'no {cls.__name__} in the current scope')
 
     def _clear_current(self, scope):
         """Clear references from self._current at the end of *scope*."""

--- a/pandasdmx/tests/data/IMF/ECOFIN_DSD-structure.xml
+++ b/pandasdmx/tests/data/IMF/ECOFIN_DSD-structure.xml
@@ -1888,6 +1888,19 @@ The concept refers to valuation rules used for recording flows and stocks, inclu
           </com:Attribute>
         </str:CubeRegion>
       </str:ContentConstraint>
+      <str:ContentConstraint urn="urn:sdmx:org.sdmx.infomodel.registry.ContentConstraint=IMF:US_Constraint(1.0)" isExternalReference="false" agencyID="IMF" id="US_Constraint" isFinal="false" type="Allowed" version="1.0">
+        <com:Name xml:lang="en">US Agencies constraint</com:Name>
+        <str:ConstraintAttachment>
+          <str:DataProvider>
+            <Ref maintainableParentID="DATA_PROVIDERS" package="base" maintainableParentVersion="1.0" agencyID="IMF" id="US3" class="DataProvider"/>
+          </str:DataProvider>
+        </str:ConstraintAttachment>
+        <str:CubeRegion include="true">
+          <com:KeyValue id="REF_AREA">
+            <com:Value>US</com:Value>
+          </com:KeyValue>
+        </str:CubeRegion>
+      </str:ContentConstraint>
     </str:Constraints>
   </mes:Structures>
 </mes:Structure>


### PR DESCRIPTION
The code handles the entire response for:
```
python -c "import pandasdmx; pandasdmx.Request('IMF').datastructure('ECOFIN_DSD')
```

However, to avoid adding this 33 MiB response to the test suite, the existing specimen is expanded.