### PR TITLE
read_sdmx - open file in binary mode, do not pass encoding from kwargs

### DIFF
--- a/doc/example.rst
+++ b/doc/example.rst
@@ -48,7 +48,7 @@ We use the built-in :func:`.to_pandas` function to convert it to a :class:`panda
 .. ipython:: python
 
     data = (sdmx.to_pandas(resp)
-                .xs('TOTAL', level='AGE', drop_level=False))
+                .xs('Y15-74', level='AGE', drop_level=False))
 
 We can now explore the data set as expressed in a familiar pandas object.
 First, show dimension names:
@@ -64,8 +64,8 @@ First, show dimension names:
 
     data.index.levels
 
-Select some data of interest: show aggregate unemployment rates across ages ('TOTAL' on the ``AGE`` dimension) and sexes ('T' on the ``SEX`` dimension), expressed as a percentage of active population ('PC_ACT' on the ``UNIT`` dimension):
+Select some data of interest: show aggregate unemployment rates across ages ('Y15-74' on the ``AGE`` dimension) and sexes ('T' on the ``SEX`` dimension), expressed as a percentage of active population ('PC_ACT' on the ``UNIT`` dimension):
 
 .. ipython:: python
 
-    data.loc[('A', 'TOTAL', 'PC_ACT', 'T')]
+    data.loc[('A', 'Y15-74', 'PC_ACT', 'T')]

--- a/pandasdmx/api.py
+++ b/pandasdmx/api.py
@@ -520,12 +520,11 @@ def read_sdmx(filename_or_obj, format=None, **kwargs):
         reader = readers[filename_or_obj.suffix.lstrip('.').upper()]
 
         # Open the file
-        # str() here is for Python 3.5 compatibility
-        obj = open(str(filename_or_obj), encoding=kwargs.pop('encoding', None))
+        obj = open(filename_or_obj, 'br')
     except KeyError:
         if format:
             reader = readers[format]
-            obj = open(str(filename_or_obj))
+            obj = open(filename_or_obj, 'br')
         else:
             msg = ("cannot identify SDMX message format from file name "
                    f"'{filename_or_obj.name}'; use  format='...'")

--- a/pandasdmx/tests/test_docs.py
+++ b/pandasdmx/tests/test_docs.py
@@ -38,9 +38,9 @@ def test_doc_example():
         )
 
     data = sdmx.to_pandas(resp) \
-               .xs('TOTAL', level='AGE', drop_level=False)
+               .xs('Y15-74', level='AGE', drop_level=False)
 
-    data.loc[('A', 'TOTAL', 'PC_ACT', 'T')]
+    data.loc[('A', 'Y15-74', 'PC_ACT', 'T')]
 
     # Further checks per https://github.com/dr-leo/pandaSDMX/issues/157
 
@@ -85,8 +85,8 @@ def test_doc_index1():
         'AT': 'Austria',
         'BE': 'Belgium',
         'BG': 'Bulgaria',
+        'CH': 'Switzerland',
         'CY': 'Cyprus',
-        'CZ': 'Czechia',
         }, name='GEO') \
         .rename_axis('CL_GEO')
 

--- a/pandasdmx/tests/test_reader_xml.py
+++ b/pandasdmx/tests/test_reader_xml.py
@@ -12,13 +12,13 @@ from .data import specimen, test_files
 # Read example data files
 @pytest.mark.parametrize('path', **test_files(format='xml', kind='data'))
 def test_read_xml(path):
-    sdmx.read_sdmx(path, encoding='utf-8')
+    sdmx.read_sdmx(path)
 
 
 # Read example structure files
 @pytest.mark.parametrize('path', **test_files(format='xml', kind='structure'))
 def test_read_xml_structure(path):
-    sdmx.read_sdmx(path, encoding='utf-8')
+    sdmx.read_sdmx(path)
 
 
 def test_read_xml_structure_insee():

--- a/pandasdmx/tests/test_writer.py
+++ b/pandasdmx/tests/test_writer.py
@@ -61,7 +61,7 @@ def test_write_data_arguments():
 
 
 def test_write_data(data_path):
-    msg = sdmx.read_sdmx(data_path, encoding='utf-8')
+    msg = sdmx.read_sdmx(data_path)
 
     result = sdmx.to_pandas(msg)
 
@@ -293,7 +293,7 @@ def test_write_dataset_datetime():
 
 @pytest.mark.parametrize('path', **test_files(kind='structure'))
 def test_writer_structure(path):
-    msg = sdmx.read_sdmx(path, encoding='utf-8')
+    msg = sdmx.read_sdmx(path)
 
     sdmx.to_pandas(msg)
 


### PR DESCRIPTION
Test suite requires adjustments. The changes in api.py seem to be correct though. The code example in #169 passes.

Closes #169 
