### PR TITLE
Update ECB base URL

### DIFF
--- a/pandasdmx/sources.json
+++ b/pandasdmx/sources.json
@@ -13,7 +13,7 @@
             "headers": {}
         }
     },
-    "url": "http://sdw-wsrest.ecb.int/service",
+    "url": "https://sdw-wsrest.ecb.europa.eu/service",
     "name": "European Central Bank",
     "documentation": "http://www.ecb.europa.eu/stats/ecb_statistics/co-operation_and_standards/sdmx/html/index.en.html",
     "supports": {"preview": true}


### PR DESCRIPTION
The ECB has recently refurbished their website. Since then, accessing ECB data is no longer possible:
```
ecb = sdmx.Request("ECB",  log_level=10)
ecb.data('EXR')
...
TooManyRedirects: Exceeded 30 redirects.
```
Changing the base URL fixes the issue. It would be great if you could release a version containing this fix ;-)
Thanks!