### PR TITLE
added countdown 2030

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -267,6 +267,16 @@ SDMX-ML —
 SDMX-ML —
 `Website <https://data.unicef.org/>`_
 
+
+
+``CD2030``: Countdown 2030
+----------------------------------------------------------------
+
+SDMX-ML —
+`Website <https://profiles.countdown2030.org/>`_
+
+
+
 ``WB``: World Bank Group's “World Integrated Trade Solution”
 ------------------------------------------------------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -69,15 +69,15 @@ Changes
 ::::::::::
 
 - add support for new data source 
+  `Countdown2030 <https://profiles.countdown2030.org/>`_ 
+- add support for new data source 
   `UNICEF <https://data.unicef.org/sdmx-api-documentation/>`_
-- Remove data source UNESCO  as their SDMX web API has been   discontinued.
+- Remove data source UNESCO  as their SDMX web API has been discontinued.
   Bulk downloads should still be available though.
 - Ported code-base   from v1.2.0 of recent 
-  `fork <http://sdmx1.readthedocs.io/>`_. New features:
-  
+  `fork <http://sdmx1.readthedocs.io/>`_. New features: 
   * event-driven SDMXML reader
-  * new sdmxml writer to serialize a programmatically generated model representation as SDMXML file (in case anyone  needs this)
-  
+  * new sdmxml writer to serialize a programmatically generated model representation as SDMXML file (in case anyone  needs this)  
 - Fix crash when passing `str` typed filepath to :func:`pandasdmx.reader.read_sdmx`
 - Add support for :class:`pandasdmx.message.DataMessage` attributes 
   *reporting_begin*, *reporting_en* and *extracted*.

--- a/pandasdmx/sources.json
+++ b/pandasdmx/sources.json
@@ -134,6 +134,15 @@
       "accept": "application/vnd.sdmx.structure+xml;version=2.1"
     }
   },
+ {
+    "id": "CD2030",
+    "name": "COUNTDOWN 2030",
+    "documentation": "https://profiles.countdown2030.org/",
+    "url": "https://sdmx.data.unicef.org/ws/public/sdmxapi/rest",
+    "headers": {
+      "accept": "application/vnd.sdmx.structure+xml;version=2.1"
+    }
+  },
   {
     "id": "SPC",
     "name": "Pacific Data Hub",


### PR DESCRIPTION
Added CD2030 as a data provider, is a medium term (e.g. to 2030) data source that UNICEF will be supporting, makes sense to add it.