### PR TITLE
Fix error message

### DIFF
--- a/pandasdmx/source/__init__.py
+++ b/pandasdmx/source/__init__.py
@@ -183,7 +183,7 @@ def add_source(info, id=None, override=False, **kwargs):
     info.update(kwargs)
 
     if id in sources and not override:
-        raise ValueError("Data source '%s' already defined; use override=True", id)
+        raise ValueError("Data source '%s' already defined; use override=True" % id)
 
     # Maybe import a subclass that defines a hook
     SourceClass = Source


### PR DESCRIPTION
Update error message to use the variable in the message instead of printing unformatted message then the variable.