### PR TITLE
Case-insensitive comparison in util.Resource.from_obj()

### DIFF
--- a/pandasdmx/util.py
+++ b/pandasdmx/util.py
@@ -125,7 +125,7 @@ class Resource(str, Enum):
     @classmethod
     def from_obj(cls, obj):
         """Return an enumeration value based on the class of `obj`."""
-        value = obj.__class__.__name__
+        value = obj.__class__.__name__.lower()
         return cls[VALUE.get(value, value)]
 
     @classmethod


### PR DESCRIPTION
Supplying a resource object (e.g. `models.Structure` to `api.Resource.get()` with a `resource` argument throws a KeyError. 

This is because the class name is camelcase and the enum element names are lowercase.

A case-insensitive match solves this.