### PR TITLE
Pydantic V2 compatibility

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
-lxml=4.9.2
+lxml==4.9.2
 requests==2.28.1
 requests-cache==0.9.7
-pandas==1.5.2
+pydantic==2.5.2
+pandas==2.1.3
 sphinx==5.3
 ipython==8.7.0
-

--- a/pandasdmx/api.py
+++ b/pandasdmx/api.py
@@ -290,7 +290,8 @@ class Request:
         url_parts.append(key)
 
         # Assemble final URL
-        url = "/".join(filter(None, url_parts))
+        url_parts = [str(x) for x in filter(None, url_parts)]
+        url = "/".join(url_parts)
 
         # Parameters: set 'references' to sensible defaults
         if "references" not in parameters:

--- a/pandasdmx/message.py
+++ b/pandasdmx/message.py
@@ -213,7 +213,8 @@ class StructureMessage(Message):
         for field, field_info in direct_fields(self.__class__).items():
             # NB for some reason mypy complains here, but not in __contains__(), below
             if isinstance(
-                obj, get_args(field_info.outer_type_)[1],  # type: ignore [attr-defined]
+                obj,
+                get_args(field_info.outer_type_)[1],  # type: ignore [attr-defined]
             ):
                 getattr(self, field)[obj.id] = obj
                 return

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -31,6 +31,7 @@ from functools import lru_cache
 from inspect import isclass
 from itertools import product
 from operator import attrgetter, itemgetter
+import pdb
 from typing import (
     Any,
     ClassVar,
@@ -861,7 +862,7 @@ class ComponentList(IdentifiableArtefact, Generic[CT]):
     #:
     components: List[CT] = []
     #:
-    auto_order: ClassVar[str] = 1
+    auto_order: ClassVar[int] = 1
 
     # The default type of the Components in the ComponentList. See comment on
     # ItemScheme._Item
@@ -914,7 +915,7 @@ class ComponentList(IdentifiableArtefact, Generic[CT]):
             # order property
             try:
                 component.order = self.auto_order
-                self.auto_order += 1
+                self.__class__.auto_order += 1
             except ValueError:
                 pass
 
@@ -1787,7 +1788,7 @@ class KeyValue(BaseModel):
     #: The actual value.
     value: Any
     #:
-    value_for: Optional[Dimension] = None
+    value_for: Optional[DimensionComponent] = None
 
     def __init__(self, *args, **kwargs):
         args, kwargs = value_for_dsd_ref("dimension", args, kwargs)

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -1822,6 +1822,9 @@ class KeyValue(BaseModel):
         else:
             return self.value == other
 
+    def __lt__(self, other):
+        return self.value < other.value
+
     def __str__(self):
         return "{0.id}={0.value}".format(self)
 

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -31,7 +31,6 @@ from functools import lru_cache
 from inspect import isclass
 from itertools import product
 from operator import attrgetter, itemgetter
-import pdb
 from typing import (
     Any,
     ClassVar,

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -749,7 +749,7 @@ class ItemScheme(MaintainableArtefact, Generic[IT]):
                 kwargs["parent"] = self[parent]
 
             # Instantiate an object of the correct class
-            obj = self._Item(**kwargs)
+            obj = self.__class__._Item.get_default()(**kwargs)
 
         try:
             # Add the object to the ItemScheme

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -603,7 +603,7 @@ class ItemScheme(MaintainableArtefact, Generic[IT]):
     # TODO add delete()
     # TODO add sorting capability; perhaps sort when new items are inserted
 
-    is_partial: Optional[bool]
+    is_partial: Optional[bool] = None
 
     #: Members of the ItemScheme. Both ItemScheme and Item are abstract classes.
     #: Concrete classes are paired: for example, a :class:`.Codelist` contains

--- a/pandasdmx/model.py
+++ b/pandasdmx/model.py
@@ -33,6 +33,7 @@ from itertools import product
 from operator import attrgetter, itemgetter
 from typing import (
     Any,
+    ClassVar,
     Dict,
     Generator,
     Generic,
@@ -745,9 +746,6 @@ class ItemScheme(MaintainableArtefact, Generic[IT]):
         return obj
 
 
-Item.update_forward_refs()
-
-
 # §3.6: Structure
 
 
@@ -863,7 +861,7 @@ class ComponentList(IdentifiableArtefact, Generic[CT]):
     #:
     components: List[CT] = []
     #:
-    auto_order = 1
+    auto_order: ClassVar[str] = 1
 
     # The default type of the Components in the ComponentList. See comment on
     # ItemScheme._Item
@@ -1040,7 +1038,7 @@ class Agency(Organisation):
 # Update forward references to 'Agency'
 for cls in list(locals().values()):
     if isclass(cls) and issubclass(cls, MaintainableArtefact):
-        cls.update_forward_refs()
+        cls.model_rebuild()
 
 
 class OrganisationScheme:
@@ -1464,8 +1462,8 @@ class GroupDimensionDescriptor(DimensionDescriptor):
         pass
 
 
-DimensionRelationship.update_forward_refs()
-GroupRelationship.update_forward_refs()
+DimensionRelationship.model_rebuild()
+GroupRelationship.model_rebuild()
 
 
 class _NullConstraintClass:
@@ -2300,6 +2298,9 @@ class ProvisionAgreement(MaintainableArtefact, ConstrainableArtefact):
     structure_usage: Optional[StructureUsage] = None
     #:
     data_provider: Optional[DataProvider] = None
+
+
+Item.model_rebuild()
 
 
 #: The SDMX-IM defines 'packages'; these are used in URNs.

--- a/pandasdmx/reader/sdmxml.py
+++ b/pandasdmx/reader/sdmxml.py
@@ -119,6 +119,7 @@ class _NoText:
 # Sentinel value for XML elements with no text; used to distinguish from "" and None
 NoText = _NoText()
 
+
 class Reference:
     """Temporary class for references.
 
@@ -205,7 +206,7 @@ class Reference:
 
 class XSDResolver(etree.Resolver):
     """
-    Resolve XSD imports to locate them within <user_data_dir>/pandaSDMX/sdmx_2_1. 
+    Resolve XSD imports to locate them within <user_data_dir>/pandaSDMX/sdmx_2_1.
     """
 
     def __init__(self, *args, schema_dir=None, **kwargs):
@@ -249,7 +250,7 @@ class Reader(BaseReader):
         must be installed first. See the docs on
         :func:`pandasdmx.api.install_schemas` and
         :meth:`pandasdmx.api.Request.validate`.
-        
+
         Returns whatever lxml.etree.XMLSchema.validate returns
         """
         msg_doc = etree.parse(msg)
@@ -829,7 +830,7 @@ def _ref(reader, elem):
 
 @end("com:Annotation")
 def _a(reader, elem):
-    url=reader.pop_single("AnnotationURL")
+    url = reader.pop_single("AnnotationURL")
     args = dict(
         title=reader.pop_single("AnnotationTitle"),
         type=reader.pop_single("AnnotationType"),
@@ -912,7 +913,7 @@ def _itemscheme(reader, elem):
     is_ = reader.maintainable(cls, elem)
 
     # Iterate over all Item objects *and* their children
-    iter_all = chain(*[iter(item) for item in reader.pop_all(cls._Item)])
+    iter_all = chain(*[iter(item) for item in reader.pop_all(cls._Item.default)])
 
     # Set of objects already added to `items`
     seen = dict()

--- a/pandasdmx/source/__init__.py
+++ b/pandasdmx/source/__init__.py
@@ -1,4 +1,6 @@
+import pdb
 from pydantic import HttpUrl
+from pydantic.fields import ModelPrivateAttr
 from enum import Enum
 from importlib import import_module, resources
 import json
@@ -31,7 +33,7 @@ class Source(BaseModel):
     id: str
     #: Optional API IDTakes precedence over id when URL is constructed
     # Useful if a provider offers several APIs
-    api_id: Optional[str]
+    api_id: Optional[str] = None
 
     #: Base URL for queries
     url: Optional[HttpUrl]
@@ -40,7 +42,7 @@ class Source(BaseModel):
     name: str
 
     #: documentation URL of the data source
-    documentation: Optional[HttpUrl]
+    documentation: Optional[HttpUrl] = None
 
     headers: Dict[str, Any] = {}
 
@@ -124,7 +126,7 @@ class Source(BaseModel):
 
     @validator("id")
     def _validate_id(cls, value):
-        assert getattr(cls, "_id", value) == value
+        assert cls.__dict__.get("_id", value) == value
         return value
 
     @validator("data_content_type", pre=True)

--- a/pandasdmx/source/__init__.py
+++ b/pandasdmx/source/__init__.py
@@ -1,6 +1,5 @@
 import pdb
 from pydantic import HttpUrl
-from pydantic.fields import ModelPrivateAttr
 from enum import Enum
 from importlib import import_module, resources
 import json

--- a/pandasdmx/source/__init__.py
+++ b/pandasdmx/source/__init__.py
@@ -1,4 +1,3 @@
-import pdb
 from pydantic import HttpUrl
 from enum import Enum
 from importlib import import_module, resources

--- a/pandasdmx/tests/test_model.py
+++ b/pandasdmx/tests/test_model.py
@@ -3,6 +3,7 @@
 import pydantic
 import pytest
 from pytest import raises
+import re
 
 from pandasdmx import model
 from pandasdmx.model import (
@@ -199,7 +200,7 @@ def test_internationalstring():
     assert str(i2.name) == "European Central Bank"
 
     # Creating with name=None raises an exception…
-    with raises(pydantic.ValidationError, match="none is not an allowed value"):
+    with raises(pydantic.ValidationError, match=re.compile(r"name\n.*input_value=None")):
         Item(id="ECB", name=None)
 
     # …giving empty dict is equivalent to giving nothing

--- a/pandasdmx/util.py
+++ b/pandasdmx/util.py
@@ -1,4 +1,5 @@
 import logging
+import pdb
 import typing
 from collections.abc import Iterator
 from enum import Enum
@@ -249,6 +250,9 @@ class DictLike(dict, typing.MutableMapping[KT, VT]):
         """Validate `v` as an entire DictLike object."""
         # Convert anything that can be converted to a dict(). pydantic internals catch
         # most other invalid types, e.g. set(); no need to handle them here.
+        if cls == DictLike:
+            return v
+
         result = cls(v)
 
         # Reference to the pydantic.field.ModelField for the entries

--- a/pandasdmx/util.py
+++ b/pandasdmx/util.py
@@ -1,5 +1,4 @@
 import logging
-import pdb
 import typing
 from collections.abc import Iterator
 from enum import Enum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,35 +10,35 @@ home-page = "https://github.com/dr-leo/pandasdmx"
 dist-name = "pandaSDMX"
 description-file = "README.rst"
 requires = [
-    "requests >=2.26",
-    "lxml >= 4.8",
-    "pandas >= 1.3",
-    "pydantic >=1.9.2, < 2.0"]
+  "requests >=2.26",
+  "lxml >= 4.8",
+  "pandas >= 1.3",
+  "pydantic >=2.0.0, <3.0",
+]
 requires-python = ">=3.9.6,<3.12"
 keywords = "statistics, SDMX, pandas, data, economics, science"
 classifiers = [
-"Intended Audience :: Developers",
-"Intended Audience :: Science/Research",
-    "Intended Audience :: Financial and Insurance Industry",
-"Development Status :: 4 - Beta",
-"Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Topic :: Scientific/Engineering",
-    "Topic :: Scientific/Engineering :: Information Analysis",
-"License :: OSI Approved :: Apache Software License"]
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "Intended Audience :: Financial and Insurance Industry",
+  "Development Status :: 4 - Beta",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+  "License :: OSI Approved :: Apache Software License",
+]
 
-[tool.flit.metadata.requires-extra]  
+[tool.flit.metadata.requires-extra]
 cache = ["requests_cache >= 0.9.5"]
 schema = ["appdirs >= 1.4"]
-doc = ["sphinx >= 5.2", 
-"IPython >= 7.20"]
-test = ["pytest >= 5", 
-"requests-mock >= 1.4"]
+doc = ["sphinx >= 5.2", "IPython >= 7.20"]
+test = ["pytest >= 5", "requests-mock >= 1.4"]
 
 [tool.flit.metadata.urls]
-    Homepage = "https://pandasdmx.readthedocs.io/en/latest/"
+Homepage = "https://pandasdmx.readthedocs.io/en/latest/"
 
 [tool.flit.sdist]
 include = ["LICENSE", 'README.rst']


### PR DESCRIPTION
Solves https://github.com/dr-leo/pandaSDMX/issues/246 WIP
- remove deprected pydantic.fields.ModelField
- replace deprecated cls.__fields__ with cls.model_fields
- replace deprecated cls.post_validations in validate_dictlike with @validator wrapper with pre=False